### PR TITLE
Changes needed to fix the UTF8 encoding bug on the casperjs scrapers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM debian:jessie
 
-RUN apt-get update && apt-get install -y fontconfig python tar bzip2
+RUN apt-get update && apt-get install -y fontconfig python tar bzip2 npm locales
+
+# Set the locale
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 # Downloading phantomjs
 ADD https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 /tmp/phantomjs-2.1.1-linux-x86_64.tar.bz2
@@ -9,6 +15,4 @@ ADD https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64
 RUN cd /tmp/ && tar -xjvf /tmp/phantomjs-2.1.1-linux-x86_64.tar.bz2 && cp /tmp/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /bin && chmod +x /bin/phantomjs && rm /tmp/phantomjs-2.1.1-linux-x86_64.tar.bz2
 
 # Installing casperjs
-ADD https://github.com/n1k0/casperjs/archive/1.1-beta5.tar.gz /usr/lib/casperjs/casperjs-1.1-beta5.tar.gz
-
-RUN cd /usr/lib/casperjs && tar -xvf /usr/lib/casperjs/casperjs-1.1-beta5.tar.gz && ln -sf /usr/lib/casperjs/casperjs-1.1-beta5/bin/casperjs /usr/local/bin/casperjs && rm -rf /usr/lib/casperjs/casperjs-1.1-beta5.tar.gz
+RUN npm install casperjs --global


### PR DESCRIPTION
- Setting environment default locales and encoding
- New dependencies: npm and locales
- Changing installation method for casperjs, now it is installed through npm (version 1.1.2)
